### PR TITLE
feat(rook-ceph): add ceph-csi-drivers chart (PR 1/2 — adopt manual install)

### DIFF
--- a/kubernetes/apps/observability/grafana/app/dashboards/kilns.json
+++ b/kubernetes/apps/observability/grafana/app/dashboards/kilns.json
@@ -457,12 +457,40 @@
         {
           "editorMode": "code",
           "expr": "kiln_sensor_bad_percent{instance=~\"$kiln\"}",
-          "legendFormat": "Failure Percentage",
+          "legendFormat": "Bad % (all types)",
           "range": true,
           "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kiln_sensor_error_count{instance=~\"$kiln\", type=\"no_connection\"}",
+          "legendFormat": "No connection",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kiln_sensor_error_count{instance=~\"$kiln\", type=\"short_to_ground\"}",
+          "legendFormat": "Short to GND",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kiln_sensor_error_count{instance=~\"$kiln\", type=\"short_to_vcc\"}",
+          "legendFormat": "Short to VCC",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "editorMode": "code",
+          "expr": "kiln_sensor_error_count{instance=~\"$kiln\", type=\"unknown_error\"}",
+          "legendFormat": "Unknown error",
+          "range": true,
+          "refId": "E"
         }
       ],
-      "title": "Bad Sensor Reads",
+      "title": "Sensor Errors",
       "type": "timeseries"
     }
   ],

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: ceph-csi-drivers
+      version: 1.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: ceph-csi-operator
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: rook-ceph-operator
+  # Values mirror the upstream recommended file:
+  # https://github.com/rook/rook/blob/release-1.20/deploy/charts/ceph-csi-drivers/values.yaml
+  # Keep in sync when bumping chart version.
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -47,3 +47,26 @@ spec:
   postBuild:
     substitute:
       APP: *app
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rook-ceph-csi-drivers
+  namespace: flux-system
+spec:
+  targetNamespace: rook-ceph
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph
+  path: ./kubernetes/apps/rook-ceph/rook-ceph/csi-drivers
+  prune: false # never should be deleted
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/flux/repositories/helm/ceph-csi-operator.yaml
+++ b/kubernetes/flux/repositories/helm/ceph-csi-operator.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ceph-csi-operator
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://ceph.github.io/ceph-csi-operator

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./dysnix.yaml
   - ./external-secrets.yaml
   - ./rook-ceph.yaml
+  - ./ceph-csi-operator.yaml
   - ./cloudnative-pg.yaml
   - ./piraeus.yaml
   - ./backube.yaml


### PR DESCRIPTION
## Summary

- Adds the `ceph-csi-drivers` Helm chart (new in Rook v1.20.0) as a Flux-managed HelmRelease, adopting the manually-installed release that fixed yesterday's outage.
- Plus an unrelated grafana kiln dashboard update.

## Context

Rook v1.20.0 introduced a breaking architectural change: CSI driver lifecycle management was split out of the `rook-ceph` chart and into a dedicated `ceph-csi-drivers` chart in a separate Helm repo (`ceph.github.io/ceph-csi-operator`). The Rook chart upgrade dropped CSI ServiceAccounts, RBAC, and Driver CR ownership from its responsibilities. Existing clusters need to install the new chart alongside the existing `rook-ceph` + `rook-ceph-cluster` releases for CSI to function.

That step was missed during the v1.20.0 upgrade. The cluster kept running on cached CSI tokens until 2026-06-07 when a CNPG operator upgrade rolled `postgres16-2`. The DaemonSet controller couldn't recreate the RBD plugin pod on node `ogg` because its referenced ServiceAccount (`rbd-nodeplugin-sa`) no longer existed. RBD mounts started failing, postgres-2 couldn't start, and the CNPG cluster sat in "Primary instance is being restarted" indefinitely.

A direct `helm install ceph-csi-drivers --namespace rook-ceph ...` from a laptop restored service. This PR brings that release under git/Flux management so the workflow is honest again.

## Changes

- `kubernetes/flux/repositories/helm/ceph-csi-operator.yaml` — new HelmRepository
- `kubernetes/flux/repositories/helm/kustomization.yaml` — wire it in
- `kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml` — new HelmRelease pinned to chart `1.0.1` (matches the running release exactly), values mirror upstream `rook/rook deploy/charts/ceph-csi-drivers/values.yaml` at `release-1.20`
- `kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/kustomization.yaml` — kustomize wrapper
- `kubernetes/apps/rook-ceph/rook-ceph/ks.yaml` — adds `rook-ceph-csi-drivers` Flux Kustomization, `dependsOn: rook-ceph` (CRDs come from the rook-ceph subchart)
- `kubernetes/apps/observability/grafana/app/dashboards/kilns.json` — unrelated kiln dashboard update (separate commit)

## Adoption is a no-op

`helm get values ceph-csi-drivers -n rook-ceph` was diffed against the values in this HelmRelease — identical content. Flux's helm-controller will see the existing release, recognise matching name/namespace/chart/version, and adopt ownership without triggering an upgrade or pod churn.

## Out of scope (handled in PR 2)

- The `rook-ceph` HelmRelease still has two values that v1.20 silently ignores: `csi.cephFSKernelMountOptions: ms_mode=prefer-crc` and `csi.enableLiveness: true`. These will be removed in a follow-up PR — left in place here to keep this change zero-touch on the `rook-ceph` chart.
- Restoring `ms_mode=prefer-crc` (now needs to be set via `kernelMountOptions` in the ceph-csi-drivers values) — also a follow-up.

## Test plan

- [ ] `kustomize build kubernetes/apps/rook-ceph/rook-ceph/csi-drivers` succeeds (verified locally)
- [ ] `kustomize build kubernetes/flux/repositories/helm` succeeds (verified locally)
- [ ] Flux source-controller picks up the new HelmRepository on reconcile
- [ ] Flux helm-controller adopts the existing `ceph-csi-drivers` release with no upgrade
- [ ] `helm -n rook-ceph history ceph-csi-drivers` shows revision 1 only (no Flux-triggered revision 2)
- [ ] All CSI nodeplugin DaemonSets remain 6/6 ready, no pod restarts
- [ ] Postgres cluster status stays "Cluster in healthy state"

🤖 Generated with [Claude Code](https://claude.com/claude-code)