### PR TITLE
chore(rook-ceph): drop dead csi.* values silently ignored since v1.20

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -27,9 +27,10 @@ spec:
     - name: snapshot-controller
       namespace: volsync-system
   values:
+    # CSI driver settings moved to the ceph-csi-drivers chart in Rook v1.20.
+    # Only image overrides and the serviceMonitor remain valid under csi.* here.
+    # See ./csi-drivers/helmrelease.yaml for driver config.
     csi:
-      cephFSKernelMountOptions: ms_mode=prefer-crc
-      enableLiveness: true
       serviceMonitor:
         enabled: true
     monitoring:


### PR DESCRIPTION
## Summary

Follow-up to #1466. Removes two values from the `rook-ceph` HelmRelease that the chart has silently ignored since the v1.20 upgrade:

- `csi.cephFSKernelMountOptions: ms_mode=prefer-crc`
- `csi.enableLiveness: true`

## Why

Rook v1.20 split CSI driver lifecycle out of the `rook-ceph` chart. The chart's values schema dropped these two keys but kept accepting (and ignoring) them silently. Net effect: the values block has been lying about what's applied.

The only `csi.*` keys the v1.20 `rook-ceph` chart still honours are image overrides and `serviceMonitor`. Keeping `csi.serviceMonitor.enabled: true` because that one is still valid.

## What this triggers on merge

Removing values triggers a helm upgrade of the `rook-ceph-operator` release. Since the values being removed were already a no-op, the rendered chart output is functionally identical — the operator pod will roll once (Flux rollout), no resource-level changes.

## Out of scope

- Restoring the `ms_mode=prefer-crc` CephFS kernel mount option that's been silently disabled since v1.20. Now needs to be set via `kernelMountOptions` under `operatorConfig.driverSpecDefaults` in the new `ceph-csi-drivers` HelmRelease. Worth a separate PR after verifying current CephFS mounts are stable without it.

## Test plan

- [ ] `kustomize build kubernetes/apps/rook-ceph/rook-ceph/app` succeeds
- [ ] Flux helm-controller triggers a single rollout of the rook-ceph-operator pod
- [ ] CSI nodeplugin DaemonSets stay 6/6 ready
- [ ] No PVC mount errors on any node

🤖 Generated with [Claude Code](https://claude.com/claude-code)