### PR TITLE
fix(cilium): rotate hubble TLS certs via cronJob

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -26,6 +26,12 @@ spec:
   values:
     hubble:
       enabled: true
+      tls:
+        auto:
+          # Default method is 'helm', which mints certs once at install
+          # and never rotates them. cronJob regenerates on a schedule.
+          method: cronJob
+          schedule: "0 0 1 */4 *"
       metrics:
         enabled:
           - dns:query


### PR DESCRIPTION
## Problem

`hubble.tls.auto.method` was never set, so it defaulted to `helm`. That method mints the CA and leaf certs once at install and reuses them forever via a chart `lookup`. There is no rotation, and the leaves carry a 365 day validity.

The leaves issued on 2025-07-21 expired on **2026-07-21**:

```
x509: certificate has expired or is not yet valid:
current time 2026-08-24T03:21:53Z is after 2026-07-21T05:22:00Z
```

`hubble-relay` had been failing its startup probe for a month, which nobody noticed because nothing else depends on it. The 1.19.5 to 1.20.1 bump restarted the pod and turned that silent failure into a stuck rollout: the upgrade stalled waiting on the relay, Flux rolled back to 1.19.5, and the rollback stalled for the same reason. It looped through roughly 70 failed helm revisions.

## Fix

Switch to `method: cronJob`, which deploys a certgen `Job` plus a `CronJob` regenerating certs every four months, comfortably inside the 365 day validity.

Neither rendered resource carries a `helm.sh/hook` annotation, so cert regeneration is not gated on a successful upgrade and cannot deadlock behind an unhealthy `hubble-relay` the way a post-upgrade hook would.

## Already done live

The expired leaves were regenerated manually from the intact `cilium-ca` to clear the stuck rollout. 1.20.1 is deployed and healthy, Hubble reports `Ok` with flows moving, and all six nodes are reachable. `cilium-ca` is valid until 2027-08-13 and was not touched.

## Note on merging

Moving off `method: helm` removes the two cert secrets from Helm's template set, so the upgrade deletes them and the certgen Job recreates them. Expect one brief `hubble-relay` restart when this merges. It self-heals.

## Verification

- `helm template` against 1.20.1 with these values renders `hubble-generate-certs` as a Job and CronJob, with no helm hook annotations
- yamllint and all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcSpLjrmQyRApHyfkppgeX